### PR TITLE
Fix GetInt fallback to default value

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -47,7 +47,11 @@ func GetInt(key string, defaults ...int64) int64 {
 
 	// Parse the value as an int
 	vInt, err := strconv.ParseInt(val, 10, 64)
-	if err != nil && !hasDefault {
+	if err != nil {
+		if hasDefault {
+			return defaults[0]
+		}
+
 		panic(fmt.Sprintf("[%s] Cannot parse environment variable %s as int, and there's no default value", envProvider.Name(), key))
 	}
 

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -143,6 +143,14 @@ func TestGetInt(t *testing.T) {
 		GetInt("TEST_KEY_INVALID_VALUE")
 	})
 
+	t.Run("GetIntInvalidValueWithDefault", func(t *testing.T) {
+		expected := int64(789)
+
+		if actual := GetInt("TEST_KEY_INVALID_VALUE", expected); actual != expected {
+			t.Errorf("GetInt did not return the default value on invalid input, expected: %d, got: %d", expected, actual)
+		}
+	})
+
 	// Restore the original envProvider
 	envProvider = originalEnvProvider
 }


### PR DESCRIPTION
## Summary
- ensure `GetInt` uses provided default when parsing fails
- cover invalid int parsing with default in unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840fa8b80f0832980b6ec2967cbb925